### PR TITLE
Refactoring money away from item

### DIFF
--- a/item.c
+++ b/item.c
@@ -2,23 +2,10 @@
 
 void print_item(char* str, item_t item)
 {
-	char istr[3];
-
-	int cents   = item.price % 100;
-	long int dollars = item.price / 100;
-
-	if (cents < 10) sprintf(istr, "0%i", cents);
-	else sprintf(istr, "%i", cents);
-	sprintf(str, "%-*s| $%li.%s", MAX_NAME_LEN, item.name, dollars, istr);
+	sprintf(str, "%-*s| " MONEY_FMT, MAX_NAME_LEN, item.name, MONEY_ARG(item.price));
 }
 
 void print_money(char* str, long int price)
 {
-	int cents = price % 100;
-	long int dollars = price / 100;
-	
-	if (cents < 10)
-	{
-		sprintf(str, "%li.0%i", dollars, cents);
-	} else sprintf(str, "%li.%i", dollars, cents);
+	sprintf(str, MONEY_FMT, MONEY_ARG(price));
 }

--- a/item.c
+++ b/item.c
@@ -2,10 +2,6 @@
 
 void print_item(char* str, item_t item)
 {
-	char spaces[11];
-	memset(spaces, 0, 11);
-	memset(spaces, ' ',	MAX_NAME_LEN - strlen(item.name));
-
 	char istr[3];
 
 	int cents   = item.price % 100;
@@ -13,7 +9,7 @@ void print_item(char* str, item_t item)
 
 	if (cents < 10) sprintf(istr, "0%i", cents);
 	else sprintf(istr, "%i", cents);
-	sprintf(str, "%s%s| $%li.%s", item.name, spaces, dollars, istr);
+	sprintf(str, "%-*s| $%li.%s", MAX_NAME_LEN, item.name, dollars, istr);
 }
 
 void print_money(char* str, long int price)

--- a/item.h
+++ b/item.h
@@ -33,4 +33,18 @@ void print_item(char*, item_t);
  */
 void print_money(char*, long int price);
 
+/* Bear with me through this preprocessor macro stuff
+ */
+
+#define getDigits(num) (1                                   /* 1 for sign */ \
+                      + sizeof (num) * CHAR_BIT / 3         /* ... for digits */ \
+                      + (sizeof (num) * CHAR_BIT % 3 > 0)   /* ... for remaining digit */ \
+                      + 1)                                  /* 1 for NUL terminator */
+
+#define MONEY_FMT    "$%*li.%2li"
+#define MONEY_ARG(p) getDigits((p) / 100), (p) / 100, (p) % 100
+
+/* Now you can use MONEY_FMT and MONEY_ARG in any *printf function
+ */
+
 #endif /* ITEM_H */


### PR DESCRIPTION
By creating a MONEY_FMT format string and a corresponding MONEY_ARG macro to expand a single integer into two integer arguments, we can now easily use these two macros anywhere else that money might be used without rewriting the logic. eg. charging for toilet paper/flushes in the toilets
